### PR TITLE
Build 71 create game over modal

### DIFF
--- a/css/play-game.css
+++ b/css/play-game.css
@@ -235,4 +235,3 @@ button {
   display: none;
 }
 /* end of play-game modal */
-

--- a/html/play-game.html
+++ b/html/play-game.html
@@ -50,13 +50,13 @@
     <!-- End Modal -->
 
     <!-- Game Over Modal -->
-    <div id="game-over-modal" class="flex" style="display: none;">
-      <div class="modal-content">
-          <h2>Game Over</h2>
-          <p>Your dragon's health has reached zero.</p>
-          <button id="restart-game">Restart Game</button>
+    <section id="game-over-modal" class="modal" style="display: none;">
+      <div class="flex">
+          <h2>GAME OVER</h2>
+          <h4>Your dragon's health has reached zero.</p>
+          <button type="button" id="restart-game">Restart Game</button>
       </div>
-    </div>
+    </section>
     <!-- End of Game Over Modal -->
 
     <!-- Dragon Containers -->

--- a/html/play-game.html
+++ b/html/play-game.html
@@ -49,6 +49,15 @@
     </div>
     <!-- End Modal -->
 
+    <!-- Game Over Modal -->
+    <div id="game-over-modal" class="flex" style="display: none;">
+      <div class="modal-content">
+          <h2>Game Over</h2>
+          <p>Your dragon's health has reached zero.</p>
+          <button id="restart-game">Restart Game</button>
+      </div>
+    </div>
+    <!-- End of Game Over Modal -->
 
     <!-- Dragon Containers -->
     <div class="game-container">

--- a/js/app.js
+++ b/js/app.js
@@ -11,7 +11,7 @@ let stats = {
 
 // Variables to control the game state
 let gameInterval;
-const statDecayRate = 10000;
+const statDecayRate = 100;
 
 // Function to start the game
 function startGame() {
@@ -76,6 +76,11 @@ function exercise() {
     renderStats()
 }
 
+function showGameOverModal() {
+    const gameOverModal = document.getElementById('game-over-modal');
+    gameOverModal.style.display = 'flex'; // Modal pops up
+
+}
 
 // Event listeners for buttons
 document.getElementById('feed').addEventListener('click', feed);

--- a/js/app.js
+++ b/js/app.js
@@ -73,14 +73,34 @@ function exercise() {
     stats.exercise = Math.min(10, stats.exercise + 2); // Increase exercise stat
     stats.hunger = Math.max(0, stats.hunger - 1); // Hunger decreases
     adjustHealthBasedOnStats(); // Adjust health immediately
-    renderStats()
+    renderStats();
 }
 
 function showGameOverModal() {
     const gameOverModal = document.getElementById('game-over-modal');
     gameOverModal.style.display = 'flex'; // Modal pops up
 
+    // Add event listener to Restart Game button
+    document.getElementById('restart-game').addEventListener('click', function() {
+        resetGame();
+    });
 }
+
+function resetGame() {
+    // Reset health stats
+    stats.hunger = 10;
+    stats.cleanliness = 10;
+    stats.happiness = 10;
+    stats.exercise = 10;
+
+    // Hide the Game Over modal
+    document.getElementById('game-over-modal').style.display = 'none';
+
+    // Re-render stats and restart the game
+    renderStats();
+    startGame();
+}
+
 
 // Event listeners for buttons
 document.getElementById('feed').addEventListener('click', feed);

--- a/js/health-bar.js
+++ b/js/health-bar.js
@@ -62,6 +62,12 @@ function adjustHealthBasedOnStats() {
     while (currentHealth < targetHealth) {
         increaseHealth();
     }
+
+    if (totalStats === 0) {
+        clearInterval(gameInterval); // Stop the game interval
+        showGameOverModal(); // Show the game over modal
+
+    }
 }
 
 


### PR DESCRIPTION
Hey man, let me know if you can take a crack at this!

I got the game over modal logic working:

- when health stats = 0, the game over modal pops up
- when you click restart game, it resets the health stats to 10 and _should_ start the game over (see the resetGame function at the bottom of app.js)

A couple of things I haven't gotten working:

- I can't get the health bar to repopulate once you click reset game
- the styling is pretty off - I'm trying not to rewrite a ton of css and just use the styling you already created for the other modals. I think there's an eloquent way to merge the styling with this modal, I just can't seem to figure that out

Also: i reduced the time interval to 1/10th of a second so the game over modal pops up almost immediately.
![Screenshot 2024-10-23 at 7 08 18 PM](https://github.com/user-attachments/assets/47cc25dc-648c-4f13-bf94-afc00dae3002)
